### PR TITLE
dynamic Explore page feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/author/:authorId" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/item-details/:nftId" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,75 +1,111 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import axios from "axios";
+import Timer from "../UI/Timer";
 
 const ExploreItems = () => {
+  const [exploreData, setExploreData] = useState([]);
+  const [itemsToShow, setItemsToShow] = useState(8);
+  const [loading, setLoading] = useState(true);
+  async function getExplore(event) {
+    setLoading(true)
+    const { data } = await axios.get(
+      `https://us-central1-nft-cloud-functions.cloudfunctions.net/explore?filter=${event}`
+    );
+    setExploreData(data);
+    setLoading(false);
+  }
+  function loadMore() {
+    setItemsToShow((prevItems) => [prevItems + 4]);
+  }
+  
+
+  useEffect(() => {
+    getExplore(exploreData);
+  }, []);
   return (
     <>
       <div>
-        <select id="filter-items" defaultValue="">
+        <select id="filter-items" onChange={(event) =>getExplore(event.target.value)} defaultValue="">
           <option value="">Default</option>
           <option value="price_low_to_high">Price, Low to High</option>
           <option value="price_high_to_low">Price, High to Low</option>
           <option value="likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
+      {loading
+        ? new Array(8).fill(0).map((element, index) => (
+            <div key={index} className="padding skeleton">
+              <div className="nft_coll">
+                <div className="nft_wrap">
+                  <div className="img-fluid--skeleton"></div>
+                </div>
+                <div className="nft_coll_pp">
+                  <div className="pp-coll--skeleton"></div>
+                </div>
+                <div className="nft_coll_info">
+                  <div className="collection--skeleton"></div>
+                  <div className="code--skeleton"></div>
+                </div>
+              </div>
             </div>
-            <div className="de_countdown">5h 30m 32s</div>
+          ))
+        : exploreData.slice(0, itemsToShow).map((explore) => {
+            const expiryDate = explore.expiryDate
+              ? new Date(explore.expiryDate)
+              : null;
+            const duration = expiryDate
+              ? expiryDate.getTime() - Date.now()
+              : null;
 
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
+            return (
+              <div
+                key={explore.id}
+                className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+                style={{ display: "block", backgroundSize: "cover" }}
+              >
+                <div className="nft__item">
+                  <div className="author_list_pp">
+                    <Link
+                      to={`/author/${explore.authorId}`}
+                      data-bs-toggle="tooltip"
+                      data-bs-placement="top"
+                    >
+                      <img className="lazy" src={explore.authorImage} alt="" />
+                      <i className="fa fa-check"></i>
+                    </Link>
+                  </div>
+                  {duration !== null ? (
+                    <div className="de_countdown">
+                      <Timer duration={duration} />
+                    </div>
+                  ) : null}
+
+                  <div className="nft__item_wrap">
+                    <Link to={`/item-details/${explore.nftId}`}>
+                      <img
+                        src={explore.nftImage}
+                        className="lazy nft__item_preview"
+                        alt=""
+                      />
+                    </Link>
+                  </div>
+                  <div className="nft__item_info">
+                    <Link to="/item-details">
+                      <h4>{explore.title}</h4>
+                    </Link>
+                    <div className="nft__item_price">{explore.price} ETH</div>
+                    <div className="nft__item_like">
+                      <i className="fa fa-heart"></i>
+                      <span>{explore.likes}</span>
+                    </div>
                   </div>
                 </div>
               </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
-            </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      ))}
+            );
+          })}
       <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
+        <Link onClick={loadMore} to="" id="loadmore" className="btn-main lead">
           Load more
         </Link>
       </div>

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,12 +1,12 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import SubHeader from "../images/subheader.jpg";
 import ExploreItems from "../components/explore/ExploreItems";
+import axios from "axios";
 
 const Explore = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">


### PR DESCRIPTION
**task**
Made the explore page have dynamic data that can be filtered through the backend API which also routes to a specific product/author page, reused the timer which I previously made in the new items feature, added a load more function to the load more button and added a skeleton loading state

**why**
So that the end-user experience can be as smooth as possible while also not feeling clunky and having too much information at once

**how**
Used Axios to hit a backend API where the endpoint can be changed depending on the filter that has been selected,
Implemented the same countdown timer and skeleton loading state that is used in the new items section.
Created a Load more button function that increases the number of NFTs that can be seen on the screen by simply increasing the .Slice by 4

![explore](https://github.com/KarlErikToom/karl-internship/assets/118373664/11ad1bbc-a3ee-4e6a-a4fc-d1f9fe875f50)
