### PR TITLE
Dynamic item-details page

### DIFF
--- a/src/components/UI/Carousel.jsx
+++ b/src/components/UI/Carousel.jsx
@@ -89,7 +89,7 @@ function Carousel() {
             <div key={collection.id} className="padding ">
               <div className="nft_coll">
                 <div className="nft_wrap">
-                  <Link to="/item-details">
+                  <Link to={`/item-details/${collection.nftId}`}>
                     <img
                       src={collection.nftImage}
                       className="lazy img-fluid"

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -142,7 +142,7 @@ const NewItems = () => {
                           </div>
                         </div>
 
-                        <Link to="/item-details">
+                        <Link to={`/item-details/${newItem.nftId}`}>
                           <img
                             src={newItem.nftImage}
                             className="lazy nft__item_preview"
@@ -151,7 +151,7 @@ const NewItems = () => {
                         </Link>
                       </div>
                       <div className="nft__item_info">
-                        <Link to="/item-details">
+                        <Link to={`/item-details/${newItem.nftId}`}>
                           <h4>{newItem.title}</h4>
                         </Link>
                         <div className="nft__item_price">

--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,7 @@
   background-color: lightgrey;
   border-radius: 50%;
 }
-.author__img--skeleton2{
+.author__img--skeleton2 {
   height: 80px;
   width: 80px;
   background-color: lightgray;
@@ -85,23 +85,61 @@
   background-color: lightgrey;
   width: 60px;
 }
-.author__wallet--skeleton{
+.author__wallet--skeleton {
   height: 12px;
   width: 160px;
   background-color: lightgray;
   margin-top: 12px;
 }
-.price--skeleton{
+.price--skeleton {
   height: 12px;
   width: 20px;
   background-color: lightgray;
   margin-top: 12px;
 }
-.btn--skeleton{
+.btn--skeleton {
   width: 120px;
   height: 42px;
   background-color: lightgray;
   margin-left: 24px;
+}
+.details--skeleton {
+  height: 42px;
+  width: 360px;
+  background-color: lightgray;
+}
+.info--skeleton {
+  height: 36px;
+  width: 300px;
+  margin-top: 24px;
+  background-color: lightgray;
+}
+.description--skeleton {
+  height: 32px;
+  width: 400px;
+  background-color: lightgray;
+}
+.owner--skeleton {
+  height: 36px;
+  width: 70px;
+  background-color: lightgray;
+  margin-top: 24px;
+}
+.author--skeleton {
+  height: 36px;
+  width: 70px;
+  background-color: lightgray;
+  margin-top: 64px;
+}
+.price--skeleton2 {
+  height: 36px;
+  width: 62px;
+  background-color: lightgray;
+}
+.img--skeleton {
+  height: 120%;
+  width: 80%;
+  background-color: lightgray;
 }
 
 .img-fluid--skeleton,
@@ -113,6 +151,13 @@
 .author__wallet--skeleton,
 .author__name--skeleton,
 .btn--skeleton,
+.details--skeleton,
+.info--skeleton,
+.description--skeleton,
+.owner--skeleton,
+.author--skeleton,
+.price--skeleton2,
+.img--skeleton,
 .price--skeleton {
   background: linear-gradient(
     90deg,
@@ -124,11 +169,10 @@
   animation: skeletonShine 1.5s linear infinite;
 }
 
-
-.unfollow{
+.unfollow {
   display: none;
 }
-.noshow{
+.noshow {
   display: none;
 }
 

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -15,7 +15,7 @@ const Author = () => {
     );
     setAuthor(data);
     setLocalFollowers(data.followers);
-    setLoading(false)
+    setLoading(false);
   }
 
   function handleFollowClick() {
@@ -52,10 +52,10 @@ const Author = () => {
                       {loading ? (
                         <div className="author__img--skeleton2"></div>
                       ) : (
-                        <img src={author.authorImage} alt="" />
+                          <img src={author.authorImage} alt="" />
                       )}
-
                       <i className="fa fa-check"></i>
+
                       <div className="profile_name">
                         {loading ? (
                           <h4>

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,14 +1,25 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
-import nftImage from "../images/nftImage.jpg";
+import { Link, useParams } from "react-router-dom";
+import axios from "axios";
 
 const ItemDetails = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-
+  const [details, setDetails] = useState([]);
+  const { nftId } = useParams();
+  const [loading, setLoading] = useState(true);
+  async function getDetails() {
+    const { data } = await axios.get(
+      `https://us-central1-nft-cloud-functions.cloudfunctions.net/itemDetails?nftId=${nftId}`
+    );
+    setDetails(data);
+    setLoading(false);
+  }
+  useEffect(() => {
+    getDetails();
+  }, []);
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
@@ -17,72 +28,120 @@ const ItemDetails = () => {
           <div className="container">
             <div className="row">
               <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
+                {loading ? (
+                  <div className="img--skeleton"></div>
+                ) : (
+                  <img
+                    src={details.nftImage}
+                    className="img-fluid img-rounded mb-sm-30 nft-image"
+                    alt=""
+                  />
+                )}
               </div>
-              <div className="col-md-6">
-                <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+              {loading ? (
+                <div className="col-md-6">
+                  <div className="item_info">
+                    <div className="details--skeleton"></div>
 
-                  <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
+                    <div className="item_info_counts">
+                      <div className="info--skeleton"></div>
                     </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
-                  </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
-                  <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
-                        </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                    <div className="description--skeleton"></div>
+                    <div className="d-flex flex-row">
+                      <div className="mr40">
+                        <div className="item_author">
+                          <div className="author_list_pp">
+                            <div className="owner--skeleton"></div>
+                          </div>
                         </div>
                       </div>
+                      <div></div>
                     </div>
-                    <div></div>
-                  </div>
-                  <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
-                        </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                    <div className="de_tab tab_simple">
+                      <div className="de_tab_content">
+                        <div className="item_author">
+                          <div className="author--skeleton"></div>
                         </div>
                       </div>
-                    </div>
-                    <div className="spacer-40"></div>
-                    <h6>Price</h6>
-                    <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
+                      <div className="spacer-40"></div>
+                      <div className="nft-item-price">
+                        <div className="price--skeleton2"></div>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              ) : (
+                <div className="col-md-6">
+                  <div className="item_info">
+                    <h2>
+                      {details.title} #{details.tag}
+                    </h2>
+
+                    <div className="item_info_counts">
+                      <div className="item_info_views">
+                        <i className="fa fa-eye"></i>
+                        {details.views}
+                      </div>
+                      <div className="item_info_like">
+                        <i className="fa fa-heart"></i>
+                        {details.likes}
+                      </div>
+                    </div>
+                    <p>{details.description}</p>
+                    <div className="d-flex flex-row">
+                      <div className="mr40">
+                        <h6>Owner</h6>
+                        <div className="item_author">
+                          <div className="author_list_pp">
+                            <Link to={`/author/${details.ownerId}`}>
+                              <img
+                                className="lazy"
+                                src={details.ownerImage}
+                                alt=""
+                              />
+                              <i className="fa fa-check"></i>
+                            </Link>
+                          </div>
+                          <div className="author_list_info">
+                            <Link to={`/author/${details.ownerId}`}>
+                              {details.ownerName}
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
+                      <div></div>
+                    </div>
+                    <div className="de_tab tab_simple">
+                      <div className="de_tab_content">
+                        <h6>Creator</h6>
+                        <div className="item_author">
+                          <div className="author_list_pp">
+                            <Link to={`/author/${details.creatorId}`}>
+                              <img
+                                className="lazy"
+                                src={details.creatorImage}
+                                alt=""
+                              />
+                              <i className="fa fa-check"></i>
+                            </Link>
+                          </div>
+                          <div className="author_list_info">
+                            <Link to={`/author/${details.creatorId}`}>
+                              {details.ownerName}
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="spacer-40"></div>
+                      <h6>Price</h6>
+                      <div className="nft-item-price">
+                        <img src={EthImage} alt="" />
+                        <span>{details.price}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </section>


### PR DESCRIPTION
**task**
Make the item details page dynamic and have the other links route to the exact item page

**why**
for the users to easily navigate and get info on certain NFTs

**how**

hit a backend API that contains the data for the details page and then use useParams to get that specific items endpoint.
Created dynamic routing where clicking an NFT sends you to item-details/nftId.
Added a skeleton loading state in case the user has slow internet to show that the page hasn't finished loading.


![details](https://github.com/KarlErikToom/karl-internship/assets/118373664/f04c85e3-de9a-49bf-ba79-6c3d0db53c59)

